### PR TITLE
[hotfix] Fix poetry deps and put back removed method

### DIFF
--- a/kuva-metadata/poetry.lock
+++ b/kuva-metadata/poetry.lock
@@ -145,19 +145,17 @@ name = "kuva-geometry"
 version = "1.0.0"
 description = "Definitions and helper functionalities for Kuva Space geometric operations"
 optional = false
-python-versions = ">=3.10,<=3.13"
-files = []
-develop = true
+python-versions = "<=3.13,>=3.10"
+files = [
+    {file = "kuva_geometry-1.0.0-py3-none-any.whl", hash = "sha256:302382ab964f818bfb8991ae285c55c2d41dfafe591815ee74a6a2b7323e1ed9"},
+    {file = "kuva_geometry-1.0.0.tar.gz", hash = "sha256:16371e62af2c4d9733ae49748a74c030c3e21eb8446f5e9e0135f9e217a42e03"},
+]
 
 [package.dependencies]
-numpy = "^1.26.4"
-numpy-quaternion = "^2022.4.4"
-pint = "^0.22"
-sympy = "^1.13.3"
-
-[package.source]
-type = "directory"
-url = "../kuva-geometry"
+numpy = ">=1.26.4,<2.0.0"
+numpy-quaternion = ">=2022.4.4,<2023.0.0"
+pint = ">=0.22,<0.23"
+sympy = ">=1.13.3,<2.0.0"
 
 [[package]]
 name = "mpmath"
@@ -806,4 +804,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<=3.13"
-content-hash = "515e579ec93680f16006d294ca99c68af518d1a9de64137ef2b69238c8affe11"
+content-hash = "38fef5b2e49a6b36380202ea0628b90177b313d4675ddb269b2f6d2c4e77f3de"

--- a/kuva-metadata/pyproject.toml
+++ b/kuva-metadata/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "kuva-metadata"
-version = "1.0.0"
+version = "1.0.1"
 description = "Definitions of Kuva Space product metadata"
 authors = ["Guillem Ballesteros <guillem@kuvaspace.com>" , "Lennert Antson <lennert.antson@kuvaspace.com>", "Arthur Vandenhoeke <arthur.vandenhoeke@kuvaspace.com>", "Olli Eloranta <olli.eloranta@kuvaspace.com>"]
 readme = "README.md"
@@ -25,11 +25,12 @@ pydantic = "^2.9.2"
 rasterio = "^1.4.1"
 shapely = "^2.0.6"
 sympy = "^1.13.3"
-# kuva-geometry = "*"
+kuva-geometry = "*"
 
-[tool.poetry.dependencies.kuva-geometry]
-path = "../kuva-geometry"
-develop = true
+# Temporarily can replace pypi version with relative dep if doing local development
+# [tool.poetry.dependencies.kuva-geometry]
+# path = "../kuva-geometry"
+# develop = true
 
 [tool.ruff.lint]
 select = [ "E", "F", "A", "DTZ", "NPY", "I", "ISC", "B003", "B004", "B015", "PTH", "D100", "D101", "D102", "D103", "D104", "D105", "D200", "W191", "W291", "W293", "N801", "N804", "N805", "T100", "S105", "S106", "S108", "S604", "S602", "S609", "UP003", "UP005", "UP006", "UP007", "UP008", "UP032", "UP035", "RUF001", "RUF200", "RUF013", "C901", "COM818", "RSE102", "EM101",]

--- a/kuva-reader/kuva_reader/reader/level0.py
+++ b/kuva-reader/kuva_reader/reader/level0.py
@@ -233,6 +233,16 @@ class Level0Product(ProductBase[MetadataLevel0]):
         bad_pixel_filename = f"{camera}_per_frame_cloud_mask.tif"
         return self._read_array(self.image_path / bad_pixel_filename)
 
+    def release_memory(self):
+        """Explicitely releases the memory of the `images` variable.
+
+        NOTE: this function is implemented because of a memory leak inside the Rioxarray
+        library that doesn't release memory properly. Only use it when the image data is
+        not needed anymore.
+        """
+        del self.images
+        self.images = None
+
 
 def generate_level_0_metafile():
     """Example function for reading a product and generating a metadata file from the

--- a/kuva-reader/poetry.lock
+++ b/kuva-reader/poetry.lock
@@ -145,43 +145,39 @@ name = "kuva-geometry"
 version = "1.0.0"
 description = "Definitions and helper functionalities for Kuva Space geometric operations"
 optional = false
-python-versions = ">=3.10,<=3.13"
-files = []
-develop = true
+python-versions = "<=3.13,>=3.10"
+files = [
+    {file = "kuva_geometry-1.0.0-py3-none-any.whl", hash = "sha256:302382ab964f818bfb8991ae285c55c2d41dfafe591815ee74a6a2b7323e1ed9"},
+    {file = "kuva_geometry-1.0.0.tar.gz", hash = "sha256:16371e62af2c4d9733ae49748a74c030c3e21eb8446f5e9e0135f9e217a42e03"},
+]
 
 [package.dependencies]
-numpy = "^1.26.4"
-numpy-quaternion = "^2022.4.4"
-pint = "^0.22"
-sympy = "^1.13.3"
-
-[package.source]
-type = "directory"
-url = "../kuva-geometry"
+numpy = ">=1.26.4,<2.0.0"
+numpy-quaternion = ">=2022.4.4,<2023.0.0"
+pint = ">=0.22,<0.23"
+sympy = ">=1.13.3,<2.0.0"
 
 [[package]]
 name = "kuva-metadata"
-version = "1.0.0"
+version = "1.0.1"
 description = "Definitions of Kuva Space product metadata"
 optional = false
-python-versions = ">=3.10,<=3.13"
-files = []
-develop = true
+python-versions = "<=3.13,>=3.10"
+files = [
+    {file = "kuva_metadata-1.0.1-py3-none-any.whl", hash = "sha256:d65da15259fa389ec37eaade14e51f370c9944e31af518f689c7fb6c8b95f831"},
+    {file = "kuva_metadata-1.0.1.tar.gz", hash = "sha256:86ae74852a8ab9eb285c687dd9f50cfeaa8a0dd0e14707e421750aec99a8d72a"},
+]
 
 [package.dependencies]
 kuva-geometry = "*"
-networkx = "^3.4.2"
-numpy = "^1.26.4"
-numpy-quaternion = "^2022.4.4"
-pint = "^0.22"
-pydantic = "^2.9.2"
-rasterio = "^1.4.1"
-shapely = "^2.0.6"
-sympy = "^1.13.3"
-
-[package.source]
-type = "directory"
-url = "../kuva-metadata"
+networkx = ">=3.4.2,<4.0.0"
+numpy = ">=1.26.4,<2.0.0"
+numpy-quaternion = ">=2022.4.4,<2023.0.0"
+pint = ">=0.22,<0.23"
+pydantic = ">=2.9.2,<3.0.0"
+rasterio = ">=1.4.1,<2.0.0"
+shapely = ">=2.0.6,<3.0.0"
+sympy = ">=1.13.3,<2.0.0"
 
 [[package]]
 name = "mpmath"
@@ -1056,4 +1052,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<=3.13"
-content-hash = "0a6dcbcee33ef8af74929f4934ffd20c0318a3608589f6a7b9280cef70d539c3"
+content-hash = "ac9fa7ce4224cd2f6d87dd1aab22d98b959080c1d8bfa6e2379d0f26e2ea353e"

--- a/kuva-reader/pyproject.toml
+++ b/kuva-reader/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "kuva-reader"
-version = "1.0.0"
+version = "1.0.1"
 description = "Manipulate the Kuva Space image and metadata formats"
 authors = ["Guillem Ballesteros <guillem@kuvaspace.com>" , "Lennert Antson <lennert.antson@kuvaspace.com>", "Arthur Vandenhoeke <arthur.vandenhoeke@kuvaspace.com>", "Olli Eloranta <olli.eloranta@kuvaspace.com>"]
 readme = "README.md"
@@ -30,17 +30,17 @@ pint = "^0.22"
 rasterio = "^1.4.1"
 xarray = "^2022.12.0"
 rioxarray = "^0.12.4"
-# kuva-geometry = "*"
-# kuva-metadata = "*"
+kuva-geometry = "*"
+kuva-metadata = "*"
 
 # Temporarily can replace pypi version with relative dep if doing local development
-[tool.poetry.dependencies.kuva-geometry]
-path = "../kuva-geometry"
-develop = true
+# [tool.poetry.dependencies.kuva-geometry]
+# path = "../kuva-geometry"
+# develop = true
 
-[tool.poetry.dependencies.kuva-metadata]
-path = "../kuva-metadata"
-develop = true
+# [tool.poetry.dependencies.kuva-metadata]
+# path = "../kuva-metadata"
+# develop = true
 
 
 [tool.ruff.lint]


### PR DESCRIPTION
Pip install wasn't working due to local dependency.

The release memory method got accidentally removed, so replacing that too. 