### PR TITLE
Bugfixes and comfort in using products with reader

### DIFF
--- a/kuva-metadata/kuva_metadata/sections_l1.py
+++ b/kuva-metadata/kuva_metadata/sections_l1.py
@@ -69,6 +69,8 @@ class Image(BaseModelWithUnits):
         Name of pixel value unit
     measured_quantity_unit
         Unit of pixel values
+    cloud_cover_percentage
+        The cloud cover percentage
     """
 
     bands: list[Band]
@@ -79,6 +81,7 @@ class Image(BaseModelWithUnits):
     source_images: list[UUID4]
     measured_quantity_name: str
     measured_quantity_unit: str
+    cloud_cover_percentage: float | None
 
     _check_angle = field_validator(
         "local_solar_zenith_angle",

--- a/kuva-metadata/pyproject.toml
+++ b/kuva-metadata/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "kuva-metadata"
-version = "1.0.1"
+version = "1.0.2"
 description = "Definitions of Kuva Space product metadata"
 authors = ["Guillem Ballesteros <guillem@kuvaspace.com>" , "Lennert Antson <lennert.antson@kuvaspace.com>", "Arthur Vandenhoeke <arthur.vandenhoeke@kuvaspace.com>", "Olli Eloranta <olli.eloranta@kuvaspace.com>"]
 readme = "README.md"

--- a/kuva-reader/README.md
+++ b/kuva-reader/README.md
@@ -38,8 +38,8 @@ The loaded product is stored in a `rioxarray` object, which contains extensive G
 ```python
 from kuva_reader import read_product
 
-l2a_product = read_product("my_data_folder/hyperfield1a_L2A_20250105T092548")
-print(l2a_product)  # Will show some main information such as image shape and CRS
+product = read_product("my_data_folder/hyperfield1a_L2A_20250105T092548")
+print(product)  # Will show some main information such as image shape and CRS
 ```
 
 This assumes a mostly untouched folder after distributing. Otherwise, you may need to
@@ -52,7 +52,21 @@ l2a_product = Level2AProduct("your/l2a/folder")
 ```
 
 The actual raster image is stored and can be analysed in `product.image`, while metadata
-information of the product is in `product.metadata`. 
+information of the product is in `product.metadata`.
+
+## Other tips
+
+The product object attributes and methods allow the retrieval of other interesting information as well:
+
+```python
+from kuva_reader import read_product
+
+product = read_product("your/product/folder")
+product.footprint(crs="EPSG:4326")  # Footprint with option to transform CRS
+product.image.shape  # The image attribute contains all the image data
+product.wavelengths  # Wavelengths corresponding to image bands
+product.crs  # CRS
+```
 
 ## Processing levels
 

--- a/kuva-reader/kuva_reader/__init__.py
+++ b/kuva-reader/kuva_reader/__init__.py
@@ -28,6 +28,7 @@ from .reader.image import (
     image_to_dtype_range,
     image_to_original_range,
     image_to_uint16_range,
+    image_footprint,
 )
 from .reader.level0 import Level0Product
 from .reader.level1 import Level1ABProduct, Level1CProduct
@@ -42,5 +43,6 @@ __all__ = [
     "image_to_dtype_range",
     "image_to_original_range",
     "image_to_uint16_range",
+    "image_footprint",
     "read_product",
 ]

--- a/kuva-reader/kuva_reader/reader/level0.py
+++ b/kuva-reader/kuva_reader/reader/level0.py
@@ -106,9 +106,9 @@ class Level0Product(ProductBase[MetadataLevel0]):
         if self.images is not None and len(self.images):
             return (
                 f"{self.__class__.__name__}"
-                f"with {len(self.images)} frames of shape {self.images[0].shape} "
-                f"and CRS '{self.images[0].rio.crs}'. "
-                f"Loaded from: '{self.image_path}'."
+                f"with {len(self.images["vis"])} frames (VIS) and "
+                f"{len(self.images["nir"])} frames for NIR. "
+                f"CRS '{self.images[0].rio.crs}'. Loaded from: '{self.image_path}'."
             )
         else:
             return f"{self.__class__.__name__} loaded from '{self.image_path}'."

--- a/kuva-reader/kuva_reader/reader/level0.py
+++ b/kuva-reader/kuva_reader/reader/level0.py
@@ -106,9 +106,9 @@ class Level0Product(ProductBase[MetadataLevel0]):
         if self.images is not None and len(self.images):
             return (
                 f"{self.__class__.__name__}"
-                f"with {len(self.images["vis"])} frames (VIS) and "
+                f"with {len(self.images["vis"])} frames for VIS and "
                 f"{len(self.images["nir"])} frames for NIR. "
-                f"CRS '{self.images[0].rio.crs}'. Loaded from: '{self.image_path}'."
+                f"CRS '{self.images["vis"].rio.crs}'. Loaded from: '{self.image_path}'."
             )
         else:
             return f"{self.__class__.__name__} loaded from '{self.image_path}'."

--- a/kuva-reader/kuva_reader/reader/level0.py
+++ b/kuva-reader/kuva_reader/reader/level0.py
@@ -6,8 +6,9 @@ import rioxarray as rx
 import xarray
 from kuva_metadata import MetadataLevel0
 from pint import UnitRegistry
+from shapely import Polygon
 
-from kuva_reader import image_to_dtype_range, image_to_original_range
+from kuva_reader import image_to_dtype_range, image_to_original_range, image_footprint
 
 from .product_base import ProductBase
 
@@ -120,6 +121,10 @@ class Level0Product(ProductBase[MetadataLevel0]):
     def keys(self) -> list[str]:
         """Easy access to the camera keys."""
         return list(self.images.keys())
+    
+    def footprint(self, crs="") -> Polygon:
+        """The product footprint as a Shapely polygon."""
+        return image_footprint(self.images["vis"], crs)
 
     def _get_data_from_sidecar(
         self, sidecar_path: Path, target_ureg: UnitRegistry | None = None

--- a/kuva-reader/kuva_reader/reader/level0.py
+++ b/kuva-reader/kuva_reader/reader/level0.py
@@ -107,9 +107,10 @@ class Level0Product(ProductBase[MetadataLevel0]):
         if self.images is not None and len(self.images):
             return (
                 f"{self.__class__.__name__}"
-                f"with {len(self.images["vis"])} frames for VIS and "
-                f"{len(self.images["nir"])} frames for NIR. "
-                f"CRS '{self.images["vis"].rio.crs}'. Loaded from: '{self.image_path}'."
+                f"with VIS shape {self.images['vis'].shape} "
+                f"and NIR shape {self.images['nir'].shape} "
+                f"(CRS '{self.images["vis"].rio.crs}'). "
+                f"Loaded from: '{self.image_path}'."
             )
         else:
             return f"{self.__class__.__name__} loaded from '{self.image_path}'."

--- a/kuva-reader/kuva_reader/reader/level0.py
+++ b/kuva-reader/kuva_reader/reader/level0.py
@@ -81,6 +81,7 @@ class Level0Product(ProductBase[MetadataLevel0]):
             )
             for camera, cube in self.metadata.image.data_cubes.items()  # type: ignore
         }
+        self.crs = self.images[list(self.images.keys())[0]].rio.crs
 
         # Read tags for images and denormalize / renormalize if needed
         self.data_tags = {camera: img.attrs for camera, img in self.images.items()}
@@ -109,8 +110,7 @@ class Level0Product(ProductBase[MetadataLevel0]):
                 f"{self.__class__.__name__}"
                 f"with VIS shape {self.images['vis'].shape} "
                 f"and NIR shape {self.images['nir'].shape} "
-                f"(CRS '{self.images["vis"].rio.crs}'). "
-                f"Loaded from: '{self.image_path}'."
+                f"(CRS '{self.crs}'). Loaded from: '{self.image_path}'."
             )
         else:
             return f"{self.__class__.__name__} loaded from '{self.image_path}'."
@@ -122,7 +122,7 @@ class Level0Product(ProductBase[MetadataLevel0]):
     def keys(self) -> list[str]:
         """Easy access to the camera keys."""
         return list(self.images.keys())
-    
+
     def footprint(self, crs="") -> Polygon:
         """The product footprint as a Shapely polygon."""
         return image_footprint(self.images["vis"], crs)

--- a/kuva-reader/kuva_reader/reader/level1.py
+++ b/kuva-reader/kuva_reader/reader/level1.py
@@ -56,6 +56,21 @@ class Level1ABProduct(ProductBase[MetadataLevel1AB]):
             rx.open_rasterio(self.image_path / "L1B.tif"),
         )
         self.data_tags = self.image.attrs
+        self.wavelengths = [
+            b.wavelength.to("nm").magnitude for b in self.metadata.image.bands
+        ]
+
+
+    def __repr__(self):
+        """Pretty printing of the object with the most important info"""
+        if self.image is not None:
+            return (
+                f"{self.__class__.__name__} with shape {self.image.shape} "
+                f"and wavelengths {self.wavelengths} (CRS: '{self.image.rio.crs}'). "
+                f"Loaded from: '{self.image_path}'."
+            )
+        else:
+            return f"{self.__class__.__name__} loaded from '{self.image_path}'"
 
     def _get_data_from_sidecar(
         self, sidecar_path: Path, target_ureg: UnitRegistry | None = None

--- a/kuva-reader/kuva_reader/reader/level1.py
+++ b/kuva-reader/kuva_reader/reader/level1.py
@@ -61,13 +61,14 @@ class Level1ABProduct(ProductBase[MetadataLevel1AB]):
         self.wavelengths = [
             b.wavelength.to("nm").magnitude for b in self.metadata.image.bands
         ]
+        self.crs = self.image.rio.crs
 
     def __repr__(self):
         """Pretty printing of the object with the most important info"""
         if self.image is not None:
             return (
                 f"{self.__class__.__name__} with shape {self.image.shape} "
-                f"and wavelengths {self.wavelengths} (CRS: '{self.image.rio.crs}'). "
+                f"and wavelengths {self.wavelengths} (CRS: '{self.crs}'). "
                 f"Loaded from: '{self.image_path}'."
             )
         else:
@@ -183,13 +184,14 @@ class Level1CProduct(ProductBase[MetadataLevel1C]):
         self.wavelengths = [
             b.wavelength.to("nm").magnitude for b in self.metadata.image.bands
         ]
+        self.crs = self.image.rio.crs
 
     def __repr__(self):
         """Pretty printing of the object with the most important info"""
         if self.image is not None:
             return (
                 f"{self.__class__.__name__} with shape {self.image.shape} "
-                f"and wavelengths {self.wavelengths} (CRS: '{self.image.rio.crs}'). "
+                f"and wavelengths {self.wavelengths} (CRS: '{self.crs}'). "
                 f"Loaded from: '{self.image_path}'."
             )
         else:

--- a/kuva-reader/kuva_reader/reader/level1.py
+++ b/kuva-reader/kuva_reader/reader/level1.py
@@ -3,8 +3,10 @@ from typing import cast
 
 import rioxarray as rx
 import xarray
+from kuva_reader import image_footprint
 from kuva_metadata import MetadataLevel1AB, MetadataLevel1C
 from pint import UnitRegistry
+from shapely import Polygon
 from xarray import Dataset
 
 from .product_base import ProductBase
@@ -60,7 +62,6 @@ class Level1ABProduct(ProductBase[MetadataLevel1AB]):
             b.wavelength.to("nm").magnitude for b in self.metadata.image.bands
         ]
 
-
     def __repr__(self):
         """Pretty printing of the object with the most important info"""
         if self.image is not None:
@@ -71,6 +72,10 @@ class Level1ABProduct(ProductBase[MetadataLevel1AB]):
             )
         else:
             return f"{self.__class__.__name__} loaded from '{self.image_path}'"
+
+    def footprint(self, crs="") -> Polygon:
+        """The product footprint as a Shapely polygon."""
+        return image_footprint(self.image, crs)
 
     def _get_data_from_sidecar(
         self, sidecar_path: Path, target_ureg: UnitRegistry | None = None
@@ -189,6 +194,10 @@ class Level1CProduct(ProductBase[MetadataLevel1C]):
             )
         else:
             return f"{self.__class__.__name__} loaded from '{self.image_path}'"
+
+    def footprint(self, crs="") -> Polygon:
+        """The product footprint as a Shapely polygon."""
+        return image_footprint(self.image, crs)
 
     def _get_data_from_sidecar(
         self, sidecar_path: Path, target_ureg: UnitRegistry | None = None

--- a/kuva-reader/kuva_reader/reader/level2.py
+++ b/kuva-reader/kuva_reader/reader/level2.py
@@ -57,13 +57,14 @@ class Level2AProduct(ProductBase[MetadataLevel2A]):
         self.wavelengths = [
             b.wavelength.to("nm").magnitude for b in self.metadata.image.bands
         ]
+        self.crs = self.image.rio.crs
 
     def __repr__(self):
         """Pretty printing of the object with the most important info"""
         if self.image is not None:
             return (
                 f"{self.__class__.__name__} with shape {self.image.shape} "
-                f"and wavelengths {self.wavelengths} (CRS: '{self.image.rio.crs}'). "
+                f"and wavelengths {self.wavelengths} (CRS: '{self.crs}'). "
                 f"Loaded from: '{self.image_path}'."
             )
         else:

--- a/kuva-reader/kuva_reader/reader/level2.py
+++ b/kuva-reader/kuva_reader/reader/level2.py
@@ -2,8 +2,10 @@ from pathlib import Path
 from typing import cast
 
 import rioxarray as rx
+from kuva_reader import image_footprint
 from kuva_metadata import MetadataLevel2A
 from pint import UnitRegistry
+from shapely import Polygon
 from xarray import Dataset
 
 from .product_base import ProductBase
@@ -66,6 +68,10 @@ class Level2AProduct(ProductBase[MetadataLevel2A]):
             )
         else:
             return f"{self.__class__.__name__} loaded from '{self.image_path}'"
+
+    def footprint(self, crs="") -> Polygon:
+        """The product footprint as a Shapely polygon."""
+        return image_footprint(self.image, crs)
 
     def _get_data_from_sidecar(
         self, sidecar_path: Path, target_ureg: UnitRegistry | None = None

--- a/kuva-reader/kuva_reader/reader/read.py
+++ b/kuva-reader/kuva_reader/reader/read.py
@@ -25,7 +25,7 @@ def read_product(
 
     product_map = {
         "L0": Level0Product,
-        "L1AB": Level1ABProduct,
+        "L1B": Level1ABProduct,
         "L1C": Level1CProduct,
         "L2A": Level2AProduct,
     }

--- a/kuva-reader/pyproject.toml
+++ b/kuva-reader/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "kuva-reader"
-version = "1.0.2"
+version = "1.0.3"
 description = "Manipulate the Kuva Space image and metadata formats"
 authors = ["Guillem Ballesteros <guillem@kuvaspace.com>" , "Lennert Antson <lennert.antson@kuvaspace.com>", "Arthur Vandenhoeke <arthur.vandenhoeke@kuvaspace.com>", "Olli Eloranta <olli.eloranta@kuvaspace.com>"]
 readme = "README.md"

--- a/kuva-reader/pyproject.toml
+++ b/kuva-reader/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "kuva-reader"
-version = "1.0.3"
+version = "1.0.4"
 description = "Manipulate the Kuva Space image and metadata formats"
 authors = ["Guillem Ballesteros <guillem@kuvaspace.com>" , "Lennert Antson <lennert.antson@kuvaspace.com>", "Arthur Vandenhoeke <arthur.vandenhoeke@kuvaspace.com>", "Olli Eloranta <olli.eloranta@kuvaspace.com>"]
 readme = "README.md"
@@ -32,16 +32,6 @@ xarray = "^2022.12.0"
 rioxarray = "^0.12.4"
 kuva-geometry = "*"
 kuva-metadata = "*"
-
-# Temporarily can replace pypi version with relative dep if doing local development
-# [tool.poetry.dependencies.kuva-geometry]
-# path = "../kuva-geometry"
-# develop = true
-
-# [tool.poetry.dependencies.kuva-metadata]
-# path = "../kuva-metadata"
-# develop = true
-
 
 [tool.ruff.lint]
 select = [ "E", "F", "A", "DTZ", "NPY", "I", "ISC", "B003", "B004", "B015", "PTH", "D100", "D101", "D102", "D103", "D104", "D105", "D200", "W191", "W291", "W293", "N801", "N804", "N805", "T100", "S105", "S106", "S108", "S604", "S602", "S609", "UP003", "UP005", "UP006", "UP007", "UP008", "UP032", "UP035", "RUF001", "RUF200", "RUF013", "C901", "COM818", "RSE102", "EM101",]


### PR DESCRIPTION
Fixed bugs:
- #43
- #45

Small improvements / additions:
- `crs` as reader class attribute
- `footprint()` as reader class method
- `__repr__()` method improvements
- README update
- Add `cloud_cover_percentage` field to L1 + L2 metadata
  - This was already pushed to version 1.0.2 from `develop`