### PR TITLE
Feature/atmospheric config to l2a

### DIFF
--- a/kuva-metadata/kuva_metadata/sections_common.py
+++ b/kuva-metadata/kuva_metadata/sections_common.py
@@ -405,8 +405,6 @@ class StateMetaBase(BaseModelWithUnits):
     ----------
     source
         String containing the source of the state variables
-    variables
-        variables of the state
     """
 
     source: str

--- a/kuva-metadata/kuva_metadata/sections_common.py
+++ b/kuva-metadata/kuva_metadata/sections_common.py
@@ -28,7 +28,7 @@ from kuva_metadata.validators import (
     check_is_utc_datetime,
     must_be_angle,
     must_be_distance,
-    must_be_mixing_ratio,
+    must_be_mixing_ratio_or_none,
     must_be_positive_distance,
     must_be_positive_float,
     must_be_positive_quantity,
@@ -440,12 +440,12 @@ class AtmosphericStateVariables(BaseModelWithUnits):
     tco3: Quantity
     tcwv: Quantity
     aot550: float
-    tc_co2: Quantity
-    mr_ch4: Quantity
+    tc_co2: Quantity | None = Field(default=None)
+    mr_ch4: Quantity | None = Field(default=None)
     pressure: Quantity
     wind_speed: Quantity
     aerosol_type: str  # coastal or maritime
-    atmospheric_season: str  # Summer or winter
+    atmospheric_season: str | None = Field(default=None)  # Summer or winter
 
     _check_press = field_validator("pressure", mode="before")(must_be_pressure)
     _check_wind_speed = field_validator("wind_speed", mode="before")(must_be_speed)
@@ -459,7 +459,7 @@ class AtmosphericStateVariables(BaseModelWithUnits):
         must_be_valid_atmospheric_season
     )
     _check_valid_mixing_ratio = field_validator("tc_co2", "mr_ch4", mode="before")(
-        must_be_mixing_ratio
+        must_be_mixing_ratio_or_none
     )
 
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
@@ -467,13 +467,17 @@ class AtmosphericStateVariables(BaseModelWithUnits):
     @field_serializer(
         "tco3",
         "tcwv",
-        "tc_co2",
-        "mr_ch4",
         "pressure",
         "wind_speed",
         when_used="json",
     )
-    def _serialize_quantity(self, q: Quantity):
+    def _serialize_quantity(self, q: Quantity | None):
+        return serialize_quantity(q)
+
+    @field_serializer("tc_co2", "mr_ch4", when_used="json")
+    def _serialize_maybe_none_quantity(self, q: Quantity | None):
+        if q is None:
+            return None
         return serialize_quantity(q)
 
 
@@ -495,11 +499,11 @@ class GeometryStateVariables(BaseModelWithUnits):
 
     """
 
-    sza: Quantity  # Between 0 and 90
-    saa: Quantity
+    sza: Quantity
+    saa: Quantity | None = Field(default=None)
     vza: Quantity
-    vaa: Quantity
-    altitude: Quantity  # Larger than -0.5
+    vaa: Quantity | None = Field(default=None)
+    altitude: Quantity | None = Field(default=None)
 
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 
@@ -510,7 +514,22 @@ class GeometryStateVariables(BaseModelWithUnits):
         "vaa",
         mode="before",
     )(must_be_angle)
+
     _check_altitude = field_validator("altitude", mode="before")(must_be_distance)
+
+    @field_serializer(
+        "sza",
+        "vza",
+        when_used="json",
+    )
+    def _serialize_quantity(self, q: Quantity):
+        return serialize_quantity(q)
+
+    @field_serializer("saa", "vaa", "altitude", when_used="json")
+    def _serialize_maybe_none_quantity(self, q: Quantity | None):
+        if q is None:
+            return None
+        return serialize_quantity(q)
 
 
 class SceneStateVariables(BaseModelWithUnits):

--- a/kuva-metadata/kuva_metadata/sections_common.py
+++ b/kuva-metadata/kuva_metadata/sections_common.py
@@ -497,7 +497,7 @@ class GeometryStateVariables(BaseModelWithUnits):
     altitude
         Altitude
 
-    For sun and view azimuth angles, we are using Libradtran's viewing and sun azimuth 
+    For sun and view azimuth angles, we are using Libradtran's viewing and sun azimuth
     angle conventions. That means:
     For vaa:
     - Sensor in the North (looking South): 0 deg
@@ -568,6 +568,11 @@ class AtmosphericState(StateMetaBase):
 
     Attributes:
     -----------
+    source: str
+        Source for the atmospheric data. Typically `CAMS` or `CAMS+acolite`
+    variables: AtmosphericStateVariables
+        Variables describing the state of the atmosphere
+
     """
 
     variables: AtmosphericStateVariables
@@ -578,6 +583,10 @@ class GeometryState(StateMetaBase):
 
     Attributes:
     -----------
+    source: str
+        Source for the geometry data. Typically `ADCS` or `ADCS+DEM+GCP`
+    variables: GeometryStateVariables
+        Geometric variables describing view and altitude
     """
 
     variables: GeometryStateVariables
@@ -588,7 +597,9 @@ class SceneState(StateMetaBase):
 
     Attributes:
     -----------
-    variables
+    source: str
+        Source for the scene state
+    variables: SceneStateVariables
         Scene variables
     """
 

--- a/kuva-metadata/kuva_metadata/sections_common.py
+++ b/kuva-metadata/kuva_metadata/sections_common.py
@@ -497,6 +497,20 @@ class GeometryStateVariables(BaseModelWithUnits):
     altitude
         Altitude
 
+    For sun and view azimuth angles, we are using Libradtran's viewing and sun azimuth 
+    angle conventions. That means:
+    For vaa:
+    - Sensor in the North (looking South): 0 deg
+    - Sensor in the East (looking West): 90 deg
+    - Sensor in the South (looking North): 180 deg
+    - Sensor in the West (looking East): 270 deg
+    For saa:
+    - Sun in the South: 0 degrees
+    - Sun in the West: 90 degrees
+    - Sun in the North: 180 degrees
+    - Sun in the East: 270 degrees
+
+    The relative azimuth angle (raa) is computed as vaa-saa
     """
 
     sza: Quantity

--- a/kuva-metadata/kuva_metadata/sections_common.py
+++ b/kuva-metadata/kuva_metadata/sections_common.py
@@ -1,6 +1,6 @@
 import typing
 from datetime import datetime
-from typing import cast
+from typing import Annotated, cast
 from zoneinfo import ZoneInfo
 
 from pint import Quantity, UnitRegistry
@@ -27,7 +27,15 @@ from kuva_metadata.serializers import (
 from kuva_metadata.validators import (
     check_is_utc_datetime,
     must_be_angle,
+    must_be_distance,
+    must_be_mixing_ratio,
     must_be_positive_distance,
+    must_be_positive_float,
+    must_be_positive_quantity,
+    must_be_pressure,
+    must_be_speed,
+    must_be_valid_aerosol_type,
+    must_be_valid_atmospheric_season,
     parse_camera_radiometric_ids,
     parse_crs_geometry,
     parse_date,
@@ -388,3 +396,188 @@ class Image(BaseModelWithUnits):
     ) -> Affine | None:
         # Don't use the passed field because we get the transform from the image
         return serialize_rio_metadata(info, "transform")
+
+
+class StateMetaBase(BaseModelWithUnits):
+    """Base class for all state metadata
+
+    Attributes
+    ----------
+    source
+        String containing the source of the state variables
+    variables
+        variables of the state
+    """
+
+    source: str
+
+
+class AtmosphericStateVariables(BaseModelWithUnits):
+    """Variables in the AtmosphericState
+
+    Attributes:
+    -----------
+    tco3
+        Total column of ozone [DU]
+    tcwv
+        Total column of water vapour [cm]
+    aot550
+        Aerosol optical thickness @ 550 nm
+    tc_co2
+        Total column of CO2 [ppm]
+    mr_ch4
+        Mixing ratio of methane [ppm]
+    pressure
+        Pressure [hPa]
+    wind_speed
+        Wind Speed [m/s]
+    aerosol_type
+        Aerosol type ('rural'/'maritime')
+    atmospheric_season
+        Atmospheric season ('midlatitude_summer'/'midlatitude_winter')
+    """
+
+    tco3: Quantity
+    tcwv: Quantity
+    aot550: float
+    tc_co2: Quantity
+    mr_ch4: Quantity
+    pressure: Quantity
+    wind_speed: Quantity
+    aerosol_type: str  # coastal or maritime
+    atmospheric_season: str  # Summer or winter
+
+    _check_press = field_validator("pressure", mode="before")(must_be_pressure)
+    _check_wind_speed = field_validator("wind_speed", mode="before")(must_be_speed)
+    _check_aerosol = field_validator("aot550", mode="before")(must_be_positive_float)
+    _check_aerosol_type = field_validator("aerosol_type", mode="before")(
+        must_be_valid_aerosol_type
+    )
+    _check_tcwv = field_validator("tcwv", mode="before")(must_be_positive_distance)
+    _check_ozone = field_validator("tco3", mode="before")(must_be_positive_quantity)
+    _check_valid_atmos_seasons = field_validator("atmospheric_season", mode="before")(
+        must_be_valid_atmospheric_season
+    )
+    _check_valid_mixing_ratio = field_validator("tc_co2", "mr_ch4", mode="before")(
+        must_be_mixing_ratio
+    )
+
+    model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
+
+    @field_serializer(
+        "tco3",
+        "tcwv",
+        "tc_co2",
+        "mr_ch4",
+        "pressure",
+        "wind_speed",
+        when_used="json",
+    )
+    def _serialize_quantity(self, q: Quantity):
+        return serialize_quantity(q)
+
+
+class GeometryStateVariables(BaseModelWithUnits):
+    """Variables in the GeometryState
+
+    Attributes:
+    -----------
+    sza
+        Sun zenith angle
+    saa
+        Sun azimuth angle
+    vza
+        View zenith angle
+    vaa
+        View azimuth angle
+    altitude
+        Altitude
+
+    """
+
+    sza: Quantity  # Between 0 and 90
+    saa: Quantity
+    vza: Quantity
+    vaa: Quantity
+    altitude: Quantity  # Larger than -0.5
+
+    model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
+
+    _check_angle = field_validator(
+        "sza",
+        "saa",
+        "vza",
+        "vaa",
+        mode="before",
+    )(must_be_angle)
+    _check_altitude = field_validator("altitude", mode="before")(must_be_distance)
+
+
+class SceneStateVariables(BaseModelWithUnits):
+    """Variables in the SceneState
+
+    Attributes:
+    -----------
+    land_percentage
+        Percentage of land in the scene (float)"""
+
+    land_percentage: Annotated[float, Field(gt=0, lt=100)] | None
+
+    model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
+
+    _check_landperc = field_validator("land_percentage", mode="before")(
+        must_be_positive_float
+    )
+
+
+class AtmosphericState(StateMetaBase):
+    """State of the atmosphere used for atmospheric correction.
+
+    Attributes:
+    -----------
+    """
+
+    variables: AtmosphericStateVariables
+
+
+class GeometryState(StateMetaBase):
+    """Geometric state (viewing, solar, geography) used for atmospheric correction.
+
+    Attributes:
+    -----------
+    """
+
+    variables: GeometryStateVariables
+
+
+class SceneState(StateMetaBase):
+    """Scene state used for atmospheric correction.
+
+    Attributes:
+    -----------
+    variables
+        Scene variables
+    """
+
+    variables: SceneStateVariables
+
+
+class AtmosphericCorrectionConfiguration(BaseModelWithUnits):
+    """Configuration of the atmospheric correction used
+
+    Attributes
+    ----------
+    method
+        Method used for atmospheric correction
+    atmospheric_state
+        Atmospheric state variables
+    geometry_state
+        Geometry state variables
+    scene_state
+        Scene state variables
+    """
+
+    method: str | None
+    atmospheric_state: AtmosphericState | None
+    geometry_state: GeometryState | None
+    scene_state: SceneState | None

--- a/kuva-metadata/kuva_metadata/sections_l2.py
+++ b/kuva-metadata/kuva_metadata/sections_l2.py
@@ -4,12 +4,12 @@ from pydantic import ConfigDict
 
 # Unused imports are kept so that common objects are available with one import
 from kuva_metadata.sections_common import (  # noqa # pylint: disable=unused-import
+    AtmosphericCorrectionConfiguration,
     Header,
     MetadataBase,
     Radiometry,
     RPCoefficients,
     Satellite,
-    AtmosphericCorrectionConfiguration,
 )
 from kuva_metadata.sections_l1 import (  # noqa # pylint: disable=unused-import
     Band,
@@ -42,9 +42,60 @@ class BandL2A(Band):
 
 
 class ImageL2A(Image):
+    """Hyperspectral L2A image metadata containing bands
+
+    Attributes
+    ----------
+    bands
+        _description_
+    local_solar_zenith_angle
+        Solar zenith angle of the image area
+    local_solar_azimuth_angle
+        Solar azimuth angle of the image area
+    local_viewing_angle
+        The angle between the satellite's pointing direction and nadir.
+    acquired_on
+        Time of image acquisition
+    source_images
+        List of database IDs of images this L1 product image has been stitched from
+    measured_quantity_name
+        Name of pixel value unit
+    measured_quantity_unit
+        Unit of pixel values
+    cloud_cover_percentage
+        The cloud cover percentage
+    footprint
+        Shapely polygon describing an estimated footprint of the satellite
+    epsg
+        EPSG code of the image coordinate reference system
+    shape
+        Shape of the image (height, width)
+    gsd
+        Ground sample distance (height, width or row, col) using projection unit in
+        CRS `epsg`.
+    transform
+        Affine transformation mapping pixel coordinates to coordinates in the CRS
+        `epsg`.
+    """
+
     bands: list[BandL2A]
 
+
 class AtCorConfigL2A(AtmosphericCorrectionConfiguration):
+    """Atmospheric correction configuration for L2A
+
+    Attributes
+    ----------
+    method
+        Method used for atmospheric correction
+    atmospheric_state
+        Atmospheric state variables
+    geometry_state
+        Geometry state variables
+    scene_state
+        Scene state variables
+    """
+
     pass
 
 

--- a/kuva-metadata/kuva_metadata/sections_l2.py
+++ b/kuva-metadata/kuva_metadata/sections_l2.py
@@ -9,6 +9,7 @@ from kuva_metadata.sections_common import (  # noqa # pylint: disable=unused-imp
     Radiometry,
     RPCoefficients,
     Satellite,
+    AtmosphericCorrectionConfiguration,
 )
 from kuva_metadata.sections_l1 import (  # noqa # pylint: disable=unused-import
     Band,
@@ -43,6 +44,9 @@ class BandL2A(Band):
 class ImageL2A(Image):
     bands: list[BandL2A]
 
+class AtCorConfigL2A(AtmosphericCorrectionConfiguration):
+    pass
+
 
 class MetadataLevel2A(MetadataBase):
     """Metadata for Level-2A products
@@ -56,5 +60,6 @@ class MetadataLevel2A(MetadataBase):
     """
 
     image: ImageL2A
+    atmospheric_correction_configuration: AtCorConfigL2A
 
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)

--- a/kuva-metadata/kuva_metadata/sections_l2.py
+++ b/kuva-metadata/kuva_metadata/sections_l2.py
@@ -106,11 +106,9 @@ class MetadataLevel2A(MetadataBase):
     ----------
     MetadataBase attributes
         All attributes included in parent MetadataBase
-    rpcs
-        Rational polynomial function coefficients for product orthorectification
     """
 
     image: ImageL2A
-    atmospheric_correction_configuration: AtCorConfigL2A
+    atmospheric_correction_configuration: AtCorConfigL2A | None = None
 
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)

--- a/kuva-metadata/kuva_metadata/utils.py
+++ b/kuva-metadata/kuva_metadata/utils.py
@@ -1,6 +1,6 @@
 from pint import UnitRegistry
 
 default_ureg = UnitRegistry()
-default_ureg.define('fraction = [] = frac')
-default_ureg.define('ppm = 1e-6 fraction')
+default_ureg.define("fraction = [] = frac")
+default_ureg.define("ppm = 1e-6 fraction")
 default_ureg.define("DU = 2.687e20 / meter ** 2 = dobson_unit")

--- a/kuva-metadata/kuva_metadata/utils.py
+++ b/kuva-metadata/kuva_metadata/utils.py
@@ -1,3 +1,6 @@
 from pint import UnitRegistry
 
 default_ureg = UnitRegistry()
+default_ureg.define('fraction = [] = frac')
+default_ureg.define('ppm = 1e-6 fraction')
+default_ureg.define("DU = 2.687e20 / meter ** 2 = dobson_unit")

--- a/kuva-metadata/kuva_metadata/validators.py
+++ b/kuva-metadata/kuva_metadata/validators.py
@@ -184,6 +184,8 @@ def must_be_unit(quantity: Quantity_, unit: str) -> Quantity:
 
 def must_be_distance(quantity: Quantity_) -> Quantity:
     """Parse a Pint unit and make sure it has units of distance"""
+    if quantity is None:
+        return None
     return must_be_unit(quantity, "meter")
 
 
@@ -240,7 +242,6 @@ def must_be_positive_time(quantity: Quantity_) -> Quantity:
     quantity = parse_quantity(quantity)
     quantity = must_be_positive_quantity(quantity)
     quantity = must_be_time(quantity)
-
     return quantity
 
 
@@ -255,14 +256,16 @@ def check_is_utc_datetime(timestamp: datetime) -> datetime:
 def must_be_positive_float(number:float) -> float:
     """Parse a float and check it is greater than zero"""
     if number <= 0:
-        msg = "Should be positive"
+        msg = f"Should be positive ({number})"
         raise ValueError(msg)
     return number
 
-def must_be_valid_atmospheric_season(atm_season:str):
+def must_be_valid_atmospheric_season(atm_season:str|None):
     """Parse atmospheric season value and check it is one of VALID_ATMOS_SEASONS"""
     if atm_season in VALID_ATMOS_SEASONS:
         return atm_season
+    elif atm_season is None:
+        return None
     else:
         msg = f"Atmospheric seasons must be one of {VALID_ATMOS_SEASONS}"
         raise ValueError(msg)
@@ -285,11 +288,16 @@ def must_be_dimensionless(quantity):
     return quantity
 
 
-def must_be_mixing_ratio(quantity):
+def must_be_mixing_ratio(quantity: Quantity):
     """ Checks that mixing ratios are dimensionless and positive."""
     quantity = parse_quantity(quantity)
     quantity = must_be_dimensionless(quantity)
     quantity = must_be_positive_quantity(quantity)
+    return quantity
+
+def must_be_mixing_ratio_or_none(quantity: Quantity|None):
+    if quantity is not None:
+        quantity = must_be_mixing_ratio(quantity)
     return quantity
 
 

--- a/kuva-metadata/kuva_metadata/validators.py
+++ b/kuva-metadata/kuva_metadata/validators.py
@@ -19,22 +19,16 @@ from .custom_types import CRSGeometry
 from .helper_types import Polygon_, Quantity_, array_3x3_, quaternion_
 from .utils import default_ureg
 
-VALID_ATMOS_SEASONS = (
-    "midlatitude_summer",
-    "midlatitude_winter"
-)
+VALID_ATMOS_SEASONS = ("midlatitude_summer", "midlatitude_winter")
 
 VALID_ATMOS_CORRECTION_METHODS = (
     "sprinkler/acolite",
     "sprinkler/tractor",
     "acolite",
-    "tractor"
+    "tractor",
 )
 
-VALID_AEROSOL_TYPES = (
-    "rural",
-    "maritime"
-)
+VALID_AEROSOL_TYPES = ("rural", "maritime")
 
 
 def parse_camera_radiometric_ids(d: dict[str, str]) -> dict[str, UUID]:
@@ -155,7 +149,7 @@ def parse_polygon(poly: Polygon_) -> Polygon:
 def parse_quantity(quantity: Quantity_) -> Quantity:
     """Parse a Pint quantity from a tuple (value, unit)"""
     if isinstance(quantity, list):
-        if not isinstance(quant := quantity[0], (int,float)):
+        if not isinstance(quant := quantity[0], (int, float)):
             raise ValueError
         if not isinstance(unit := quantity[1], str):
             raise ValueError
@@ -253,14 +247,16 @@ def check_is_utc_datetime(timestamp: datetime) -> datetime:
 
     return timestamp
 
-def must_be_positive_float(number:float) -> float:
+
+def must_be_positive_float(number: float) -> float:
     """Parse a float and check it is greater than zero"""
     if number <= 0:
         msg = f"Should be positive ({number})"
         raise ValueError(msg)
     return number
 
-def must_be_valid_atmospheric_season(atm_season:str|None):
+
+def must_be_valid_atmospheric_season(atm_season: str | None):
     """Parse atmospheric season value and check it is one of VALID_ATMOS_SEASONS"""
     if atm_season in VALID_ATMOS_SEASONS:
         return atm_season
@@ -270,7 +266,8 @@ def must_be_valid_atmospheric_season(atm_season:str|None):
         msg = f"Atmospheric seasons must be one of {VALID_ATMOS_SEASONS}"
         raise ValueError(msg)
 
-def must_be_valid_aerosol_type(aerosol_type:str):
+
+def must_be_valid_aerosol_type(aerosol_type: str):
     """Parse atmospheric season value and check it is one of VALID_ATMOS_SEASONS"""
     if aerosol_type in VALID_AEROSOL_TYPES:
         return aerosol_type
@@ -280,7 +277,7 @@ def must_be_valid_aerosol_type(aerosol_type:str):
 
 
 def must_be_dimensionless(quantity):
-    """ Checks if quantity is dimensionless"""
+    """Checks if quantity is dimensionless"""
     quantity = parse_quantity(quantity)
     if not quantity.is_compatible_with(default_ureg.fraction):
         msg = "Quantity is not dimensionless"
@@ -289,16 +286,17 @@ def must_be_dimensionless(quantity):
 
 
 def must_be_mixing_ratio(quantity: Quantity):
-    """ Checks that mixing ratios are dimensionless and positive."""
+    """Checks that mixing ratios are dimensionless and positive."""
     quantity = parse_quantity(quantity)
     quantity = must_be_dimensionless(quantity)
     quantity = must_be_positive_quantity(quantity)
     return quantity
 
-def must_be_mixing_ratio_or_none(quantity: Quantity|None):
+
+def must_be_mixing_ratio_or_none(quantity: Quantity | None):
+    """ Checks that entry is mixing ratio or None."""
+    # Note that None check is important for quantities which may not be present in some
+    # atmospheric correction methods.
     if quantity is not None:
         quantity = must_be_mixing_ratio(quantity)
     return quantity
-
-
-

--- a/kuva-metadata/kuva_metadata/validators.py
+++ b/kuva-metadata/kuva_metadata/validators.py
@@ -19,6 +19,23 @@ from .custom_types import CRSGeometry
 from .helper_types import Polygon_, Quantity_, array_3x3_, quaternion_
 from .utils import default_ureg
 
+VALID_ATMOS_SEASONS = (
+    "midlatitude_summer",
+    "midlatitude_winter"
+)
+
+VALID_ATMOS_CORRECTION_METHODS = (
+    "sprinkler/acolite",
+    "sprinkler/tractor",
+    "acolite",
+    "tractor"
+)
+
+VALID_AEROSOL_TYPES = (
+    "rural",
+    "maritime"
+)
+
 
 def parse_camera_radiometric_ids(d: dict[str, str]) -> dict[str, UUID]:
     """Parse the camera_radiometric_ids dict to convert string UUIDs to UUID objects."""
@@ -138,7 +155,7 @@ def parse_polygon(poly: Polygon_) -> Polygon:
 def parse_quantity(quantity: Quantity_) -> Quantity:
     """Parse a Pint quantity from a tuple (value, unit)"""
     if isinstance(quantity, list):
-        if not isinstance(quant := quantity[0], float):
+        if not isinstance(quant := quantity[0], (int,float)):
             raise ValueError
         if not isinstance(unit := quantity[1], str):
             raise ValueError
@@ -200,7 +217,7 @@ def must_be_pressure(quantity: Quantity_) -> Quantity:
 def must_be_positive_quantity(quantity: Quantity_) -> Quantity:
     """Parse a Pint unit and make sure its positive"""
     quantity = parse_quantity(quantity)
-    if quantity <= 0:
+    if quantity.magnitude <= 0:
         msg = "Should be positive"
         raise ValueError(msg)
     return quantity
@@ -234,3 +251,46 @@ def check_is_utc_datetime(timestamp: datetime) -> datetime:
         raise ValueError(msg)
 
     return timestamp
+
+def must_be_positive_float(number:float) -> float:
+    """Parse a float and check it is greater than zero"""
+    if number <= 0:
+        msg = "Should be positive"
+        raise ValueError(msg)
+    return number
+
+def must_be_valid_atmospheric_season(atm_season:str):
+    """Parse atmospheric season value and check it is one of VALID_ATMOS_SEASONS"""
+    if atm_season in VALID_ATMOS_SEASONS:
+        return atm_season
+    else:
+        msg = f"Atmospheric seasons must be one of {VALID_ATMOS_SEASONS}"
+        raise ValueError(msg)
+
+def must_be_valid_aerosol_type(aerosol_type:str):
+    """Parse atmospheric season value and check it is one of VALID_ATMOS_SEASONS"""
+    if aerosol_type in VALID_AEROSOL_TYPES:
+        return aerosol_type
+    else:
+        msg = f"Atmospheric seasons must be one of {VALID_ATMOS_SEASONS}"
+        raise ValueError(msg)
+
+
+def must_be_dimensionless(quantity):
+    """ Checks if quantity is dimensionless"""
+    quantity = parse_quantity(quantity)
+    if not quantity.is_compatible_with(default_ureg.fraction):
+        msg = "Quantity is not dimensionless"
+        raise ValueError(msg)
+    return quantity
+
+
+def must_be_mixing_ratio(quantity):
+    """ Checks that mixing ratios are dimensionless and positive."""
+    quantity = parse_quantity(quantity)
+    quantity = must_be_dimensionless(quantity)
+    quantity = must_be_positive_quantity(quantity)
+    return quantity
+
+
+

--- a/kuva-metadata/kuva_metadata/validators.py
+++ b/kuva-metadata/kuva_metadata/validators.py
@@ -294,7 +294,7 @@ def must_be_mixing_ratio(quantity: Quantity):
 
 
 def must_be_mixing_ratio_or_none(quantity: Quantity | None):
-    """ Checks that entry is mixing ratio or None."""
+    """Checks that entry is mixing ratio or None."""
     # Note that None check is important for quantities which may not be present in some
     # atmospheric correction methods.
     if quantity is not None:

--- a/kuva-metadata/tests/test_data/atcor_config_metadata.json
+++ b/kuva-metadata/tests/test_data/atcor_config_metadata.json
@@ -1,0 +1,39 @@
+{
+    "method": "sprinkler/tractor",                          
+    "atmospheric_state":
+    {
+        "source": "CAMS",                                   
+        "variables": {
+            "tco3": [ 289.3, "DU"],                         
+            "tcwv": [1.477, "cm"],                          
+            "aot550": 0.395,                                
+            "tc_co2": [ 425, "ppm"],                         
+            "mr_ch4": [ 1.88, "ppm"],                       
+            "pressure": [988.27, "hPa"],                    
+            "wind_speed": [ 6.23, "m/s"],                   
+            "aerosol_type": "rural",                        
+            "atmospheric_season": "midlatitude_summer"   
+        }
+    },
+    "geometry_state":
+    {
+        "source": "ADCS+DEM",                                   
+        "variables":
+        {
+            "sza": [21.286901, "degrees"], 
+            "saa": [266.86673, "degrees"], 
+            "vza": [11.634028, "degrees"], 
+            "vaa": [278.853954, "degrees"],
+            "altitude": [0.129, "km"]     
+            
+        }
+    },
+    "scene_state":
+    {
+        "source": "internal",
+        "variables":
+        {
+            "land_percentage": 21
+        }
+    }    
+}

--- a/kuva-metadata/tests/test_products.py
+++ b/kuva-metadata/tests/test_products.py
@@ -11,6 +11,7 @@ from shapely import Point, from_wkt
 from kuva_metadata.custom_types import CRSGeometry
 from kuva_metadata.sections_common import swap_ureg_in_instance
 from kuva_metadata.sections_l0 import Band, Frame
+from kuva_metadata.sections_l2 import AtCorConfigL2A
 
 
 @pytest.fixture(scope="module")
@@ -73,6 +74,20 @@ def test_metadata_json_load(test_data_path):
 
     assert band.frames[0].integration_time.to("s").magnitude == 1.2
     assert band_with_ureg.frames[0].integration_time.to("s").magnitude == 1.2
+
+def test_atmos_metadata_json_load(test_data_path):
+    """Check that a metadata object is correctly validated from JSON"""
+    with (test_data_path / "atcor_config_metadata.json").open() as fh:
+        atcor_config_json_data = fh.read()
+    atcor_config = AtCorConfigL2A.model_validate_json(atcor_config_json_data)
+    #atcor_config_with_ureg = AtCorConfigL2A.model_validate_json_with_ureg(atcor_config_json_data, UnitRegistry())
+
+    assert atcor_config.method == "sprinkler/tractor"
+    assert atcor_config.atmospheric_state.source == "CAMS"
+    assert atcor_config.atmospheric_state.variables.pressure.to("hPa").magnitude == 988.27
+    # assert atcor_config_with_ureg.frames[0].integration_time.to("s").magnitude == 1.2
+
+
 
 
 def test_ureg_swap(ureg, band_metadata):

--- a/kuva-metadata/uv.lock
+++ b/kuva-metadata/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-05-26T20:22:22.817964623Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "affine"
 version = "2.4.0"
@@ -125,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "kuva-metadata"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "kuva-geometry" },

--- a/kuva-reader/kuva_reader/reader/level2.py
+++ b/kuva-reader/kuva_reader/reader/level2.py
@@ -153,6 +153,7 @@ class Level2AProduct(ProductBase[MetadataLevel2A]):
                         "gsd_w": gsd_w,
                         "gsd_h": gsd_h,
                     },
+                    exclude_none=True   # This prevents "null" entries from being shown in the metadata
                 )
             )
 

--- a/kuva-reader/kuva_reader/reader/level2.py
+++ b/kuva-reader/kuva_reader/reader/level2.py
@@ -153,7 +153,7 @@ class Level2AProduct(ProductBase[MetadataLevel2A]):
                         "gsd_w": gsd_w,
                         "gsd_h": gsd_h,
                     },
-                    exclude_none=True   # This prevents "null" entries from being shown in the metadata
+                    exclude_none=True,  # This prevents "null" entries from being shown in the metadata
                 )
             )
 


### PR DESCRIPTION
Adds atmospheric correction metadata for L2A products.

- Dictionaries for tractor and acolite processed products are slightly different
- If a parameter is not found in a particular atmcor routine, the parameters are not shown in the json (see the `exclude_none=True` in `Level2AProduct.generate_metadata_file()`