### PR TITLE
Add "continental" to list of valid atmosphere types.

### DIFF
--- a/kuva-metadata/kuva_metadata/validators.py
+++ b/kuva-metadata/kuva_metadata/validators.py
@@ -28,7 +28,7 @@ VALID_ATMOS_CORRECTION_METHODS = (
     "tractor",
 )
 
-VALID_AEROSOL_TYPES = ("rural", "maritime")
+VALID_AEROSOL_TYPES = ("rural", "maritime", "continental")
 
 
 def parse_camera_radiometric_ids(d: dict[str, str]) -> dict[str, UUID]:
@@ -272,7 +272,7 @@ def must_be_valid_aerosol_type(aerosol_type: str):
     if aerosol_type in VALID_AEROSOL_TYPES:
         return aerosol_type
     else:
-        msg = f"Atmospheric seasons must be one of {VALID_ATMOS_SEASONS}"
+        msg = f"Atmospheric type must be one of {VALID_AEROSOL_TYPES}"
         raise ValueError(msg)
 
 


### PR DESCRIPTION
- Acolite uses a different atmosphere type (`continental` vs `rural`) over land
- The validator was only expecting (`rural` or `maritime`) -> added a third type (`continental`) to the list of valid options
- The error message was a copy-paste from the previous parameter, thus mixing up atmospheric type and atmospheric season. -> fixed error message