### PR TITLE
refactor: update ray intersection functions for clarity and consistency

### DIFF
--- a/kuva-geometry/kuva_geometry/ellipsoid.py
+++ b/kuva-geometry/kuva_geometry/ellipsoid.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from math import atan2
 
 import numpy as np
-from sympy import Matrix, cos, lambdify, sin, solve, sqrt, symbols
+from sympy import Matrix, cos, lambdify, sin, sqrt, symbols
 
 from .constants import EARTH_SEMIMAJOR_AXIS, EARTH_SEMIMINOR_AXIS
 
@@ -217,73 +217,19 @@ def basis_at_point(
     return [basis_vectors_𝜆, basis_vectors_𝜑, basis_vectors_h]
 
 
-def _solve_ray_ellipsoid_intersection():
-    # Symbols
-    # a: semimajor axis of the ellipsoid
-    # b: semiminor axis of the ellipsoid
-    # t: parametrizes position along the line
-    # u,v,w: parametrize the ray direction
-    # x0,y0,z0: parametrize the ray origin
-    a, b, t, u, v, w, x0, y0, z0 = symbols("a, b, t, u, v, w, x0, y0, z0")
+def _select_nearest_forward_t(solutions: np.ndarray) -> np.ndarray | float:
+    """Return the closest forward intersection along one or more rays."""
+    forward_solutions = np.where(solutions >= 0, solutions, np.inf)
+    shortest_t = np.min(forward_solutions, axis=0)
 
-    ray_origin = Matrix([x0, y0, z0])
-    ray_direction = Matrix([u, v, w])
+    if np.any(~np.isfinite(shortest_t)):
+        e_ = "Ray(s) don't intersect the ellipsoid in the forward direction"
+        raise ValueError(e_)
 
-    line = ray_origin + t * ray_direction
+    if np.ndim(shortest_t) == 0:
+        return float(shortest_t)
 
-    # We want to solve the following equation == 0
-    ts = solve((line[0] / a) ** 2 + (line[1] / a) ** 2 + (line[2] / b) ** 2 - 1, t)
-
-    ts_first = lambdify([a, b, u, v, w, x0, y0, z0], ts[0], modules="numpy")
-    ts_second = lambdify([a, b, u, v, w, x0, y0, z0], ts[1], modules="numpy")
-
-    return ts_first, ts_second
-
-
-_cached_ray_ellipsoid_solution = _solve_ray_ellipsoid_intersection()
-
-
-def ray_ellipsoid_intersection(
-    ray_origin: np.ndarray, ray_direction: np.ndarray, ellipsoid: Ellipsoid
-) -> np.ndarray:
-    """Calculate the intersection of a ray and an ellipsoid
-
-    Parameters
-    ----------
-    ray_origin
-        Origin point of ray
-    ray_direction
-        Direction of ray
-    ellipsoid
-        Ellipsoid to calculate intersection with
-
-    Returns
-    -------
-        Intersection of a ray and ellipsoid
-    """
-    t_1 = _cached_ray_ellipsoid_solution[0](
-        ellipsoid.major_axis,
-        ellipsoid.minor_axis,
-        *ray_direction,
-        *ray_origin,
-    )
-    t_2 = _cached_ray_ellipsoid_solution[1](
-        ellipsoid.major_axis,
-        ellipsoid.minor_axis,
-        *ray_direction,
-        *ray_origin,
-    )
-
-    t_sol = min(t_1, t_2)
-
-    return ray_origin + t_sol * ray_direction
-
-
-def ray_Earth_intersection(
-    ray_origin: np.ndarray, ray_direction: np.ndarray
-) -> np.ndarray:
-    """Calculate where a ray intersects with the Earth"""
-    return ray_ellipsoid_intersection(ray_origin, ray_direction, Earth)
+    return shortest_t
 
 
 def basis_at_geoid(𝜑: float, 𝜆: float, h: float):
@@ -291,58 +237,27 @@ def basis_at_geoid(𝜑: float, 𝜆: float, h: float):
     return basis_at_point(𝜑, 𝜆, h, Earth)
 
 
-def ray_ellipsoid_intersection_new(
+def _ray_ellipsoid_intersection_t(
     ray_origin: np.ndarray, ray_directions: np.ndarray, ellipsoid: Ellipsoid
-) -> np.ndarray:
-    """Calculate the intersection of a ray and an ellipsoid
+) -> np.ndarray | float:
+    """Return forward ray parameters for one or more ray/ellipsoid intersections."""
+    ray_origin = np.asarray(ray_origin, dtype=np.float64)
+    ray_directions = np.asarray(ray_directions, dtype=np.float64)
 
-    Parameters
-    ----------
-    ray_origin
-        Origin point of ray
-    ray_direction
-        Direction of ray
-    ellipsoid
-        Ellipsoid to calculate intersection with
+    if ray_origin.shape != (3,):
+        e_ = "Ray origin must be a 1d array of length 3"
+        raise ValueError(e_)
 
-    Returns
-    -------
-        Intersection of a ray and ellipsoid
-    """
-    shortest_t = vectorized_ray_ellipsoid_intersection(
-        ellipsoid.major_axis,
-        ellipsoid.minor_axis,
-        *ray_origin,
-        ray_directions,
-    )
+    is_single_ray = ray_directions.ndim == 1
+    ray_directions = np.atleast_2d(ray_directions)
 
-    return ray_origin + shortest_t[:, None] * ray_directions
+    if ray_directions.shape[1] != 3:
+        e_ = "Ray directions must have shape (3,) or (n_rays, 3)"
+        raise ValueError(e_)
 
-
-def vectorized_ray_ellipsoid_intersection(
-    a: float,
-    b: float,
-    x0: float,
-    y0: float,
-    z0: float,
-    ray_directions: np.ndarray,
-) -> np.ndarray:
-    """
-    Parameters
-    ----------
-    a, b
-        Axis of the ellipsoid
-    x0, y0, z0
-        Origin of the rays
-    u, v, w
-        Components of the ray direction. This can be arrays as long as all have the same len
-
-    Returns
-    -------
-    np.ndarray, np.ndarray
-
-    The two solutions for each of the rays
-    """
+    a = ellipsoid.major_axis
+    b = ellipsoid.minor_axis
+    x0, y0, z0 = ray_origin
     u, v, w = ray_directions[:, 0], ray_directions[:, 1], ray_directions[:, 2]
 
     discrim = (
@@ -362,16 +277,34 @@ def vectorized_ray_ellipsoid_intersection(
     den = a**2 * w**2 + b**2 * u**2 + b**2 * v**2
     indep = -(a**2) * w * z0 - b**2 * u * x0 - b**2 * v * y0
 
-    sol1 = (indep - b * np.sqrt(discrim)) / den
-    sol2 = (indep + b * np.sqrt(discrim)) / den
-
+    sqrt_discrim = np.sqrt(discrim)
+    sol1 = (indep - b * sqrt_discrim) / den
+    sol2 = (indep + b * sqrt_discrim) / den
     sols = np.vstack([sol1, sol2])
 
-    return np.min(sols, axis=0)
+    if is_single_ray:
+        return _select_nearest_forward_t(sols[:, 0])
+
+    return _select_nearest_forward_t(sols)
 
 
-def ray_Earth_intersection_new(
+def ray_ellipsoid_intersection(
+    ray_origin: np.ndarray, ray_directions: np.ndarray, ellipsoid: Ellipsoid
+) -> np.ndarray:
+    """Calculate the intersections of one or more rays and an ellipsoid."""
+    ray_origin = np.asarray(ray_origin, dtype=np.float64)
+    ray_directions = np.asarray(ray_directions, dtype=np.float64)
+    shortest_t = _ray_ellipsoid_intersection_t(ray_origin, ray_directions, ellipsoid)
+
+    if ray_directions.ndim == 1:
+        return ray_origin + float(shortest_t) * ray_directions
+
+    shortest_t_array = np.asarray(shortest_t, dtype=np.float64)
+    return ray_origin + shortest_t_array[:, None] * ray_directions
+
+
+def ray_Earth_intersection(
     ray_origin: np.ndarray, ray_directions: np.ndarray
 ) -> np.ndarray:
-    """Calculate where a ray intersects with the Earth"""
-    return ray_ellipsoid_intersection_new(ray_origin, ray_directions, Earth)
+    """Calculate where one or more rays intersect with the Earth."""
+    return ray_ellipsoid_intersection(ray_origin, ray_directions, Earth)

--- a/kuva-geometry/tests/test_ellipsoid.py
+++ b/kuva-geometry/tests/test_ellipsoid.py
@@ -1,6 +1,13 @@
 import numpy as np
+import pytest
 
-from kuva_geometry.ellipsoid import geodetic_to_xyz, xyz_to_geodetic
+from kuva_geometry.ellipsoid import (
+    Earth,
+    geodetic_to_xyz,
+    ray_Earth_intersection,
+    ray_ellipsoid_intersection,
+    xyz_to_geodetic,
+)
 
 
 def test_geoid_to_ecef_roundtrip():
@@ -11,3 +18,76 @@ def test_geoid_to_ecef_roundtrip():
     back_to_geo = xyz_to_geodetic(*to_xyz)
     error = np.abs(np.array(back_to_geo) - np.array((28, -17, 737)))
     assert np.all(error < 1e-3)
+
+
+def test_ray_ellipsoid_intersection_uses_forward_root_for_inside_origin():
+    origin = np.array([0.0, 0.0, 0.0])
+    direction = np.array([1.0, 0.0, 0.0])
+
+    intersection = ray_ellipsoid_intersection(origin, direction, Earth)
+    intersections = ray_ellipsoid_intersection(origin, np.array([direction]), Earth)
+
+    expected = np.array([Earth.major_axis, 0.0, 0.0])
+    assert np.allclose(intersection, expected)
+    assert np.allclose(intersections[0], expected)
+
+
+def test_ray_ellipsoid_intersection_rejects_away_pointing_rays():
+    origin = np.array([7000000.0, 0.0, 0.0])
+    direction = np.array([1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="forward direction"):
+        ray_ellipsoid_intersection(origin, direction, Earth)
+
+    with pytest.raises(ValueError, match="forward direction"):
+        ray_ellipsoid_intersection(origin, np.array([direction]), Earth)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[0.0], [0.0], [0.0]]),
+    ],
+)
+def test_ray_ellipsoid_intersection_rejects_invalid_origin_shapes(origin):
+    direction = np.array([1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="Ray origin must be a 1d array of length 3"):
+        ray_ellipsoid_intersection(origin, direction, Earth)
+
+
+@pytest.mark.parametrize(
+    "directions",
+    [
+        np.array([[1.0, 0.0], [0.0, 1.0]]),
+        np.array([[1.0], [0.0], [0.0]]),
+    ],
+)
+def test_ray_ellipsoid_intersection_rejects_invalid_direction_shapes(directions):
+    origin = np.array([0.0, 0.0, 0.0])
+
+    with pytest.raises(
+        ValueError, match=r"Ray directions must have shape \(3,\) or \(n_rays, 3\)"
+    ):
+        ray_ellipsoid_intersection(origin, directions, Earth)
+
+
+@pytest.mark.filterwarnings("ignore:invalid value encountered in sqrt:RuntimeWarning")
+def test_ray_ellipsoid_intersection_rejects_rays_that_miss_ellipsoid():
+    origin = np.array([0.0, 0.0, Earth.minor_axis + 1000.0])
+    direction = np.array([1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="forward direction"):
+        ray_ellipsoid_intersection(origin, direction, Earth)
+
+
+def test_ray_ellipsoid_intersection_accepts_batch_inputs():
+    origin = np.array([7000000.0, 0.0, 0.0])
+    directions = np.array([[-1.0, 0.0, 0.0], [-0.9, 0.1, 0.0]])
+
+    intersections = ray_ellipsoid_intersection(origin, directions, Earth)
+    earth_intersections = ray_Earth_intersection(origin, directions)
+
+    assert intersections.shape == (2, 3)
+    assert np.allclose(intersections, earth_intersections)

--- a/kuva-metadata/kuva_metadata/geometry_utils.py
+++ b/kuva-metadata/kuva_metadata/geometry_utils.py
@@ -125,7 +125,7 @@ def frame_ray_Earth_intersections(
 
     rays = rays / np.sqrt((rays**2).sum(axis=1))[:, None]
 
-    intersections = ellipsoid.ray_Earth_intersection_new(sat_pos, rays)
+    intersections = ellipsoid.ray_Earth_intersection(sat_pos, rays)
 
     match mode:
         case "shapely":


### PR DESCRIPTION
In this PR:
- Refactored ray/ellipsoid intersection logic to use one vectorized implementation for both single-ray and batch-ray inputs.
- Updated ray intersection selection to use the nearest forward intersection and raise ValueError when no forward intersection exists.